### PR TITLE
Remove node-version

### DIFF
--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -8,7 +8,6 @@ parameters:
 steps:
   - node/install:
       install-yarn: false
-      node-version: "18.17.1"
   - restore_cache:
       key: bun-{{ arch }}-<< parameters.version >>
   - run:


### PR DESCRIPTION
Fixes: #1 

This allows for any `.nvmrc`-file to dictate which version of node should be installed.